### PR TITLE
website: change section title Kubeflow Tutorial to Tutorials

### DIFF
--- a/website/content/en/docs/kubeflow-tutorial/_index.md
+++ b/website/content/en/docs/kubeflow-tutorial/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Kubeflow Tutorial"
+title = "Tutorials"
 description = "Explore component guides for Kubeflow on vSphere"
 weight = 20
 +++


### PR DESCRIPTION
Make it more apparent that we are talking about Tutorials for "Kubeflow on vSphere", not Tutorials for "Kubeflow".
We don't need to mention "Kubeflow on vSphere" in the section title again, as the website itself is called Kubeflow on vSphere